### PR TITLE
Fix 'Does not correctly handle verification_failed errors of API'

### DIFF
--- a/lib/hunter/email_verifier.rb
+++ b/lib/hunter/email_verifier.rb
@@ -22,7 +22,7 @@ module Hunter
       url = URI.parse(URI.encode("#{API_VERIFY_URL}email=#{@email}&api_key=#{@key}"))
       response = Faraday.new(url).get
 
-      return { status: 'delayed' } if response.status == 202
+      return { status: 'delayed' } if [202, 222].include?(response.status)
 
       if response.success?
         JSON.parse(response.body, symbolize_names: true)[:data].merge!(status: 'success')

--- a/spec/hunter_spec.rb
+++ b/spec/hunter_spec.rb
@@ -58,4 +58,24 @@ describe Hunter do
       expect(hunter.email_verifier('hello@prospect.io').status).to eq('delayed')
     end
   end
+
+  context 'delayed response from API' do
+    before(:each) do
+      response = double
+      allow(response).to receive(:success?) { true }
+      allow(response).to receive(:status) { 222 }
+      allow(response).to receive(:body) do
+        '{"errors": [{"id": "verification_failed","code": 222,"details": "We '\
+        'failed to verify the email address for reasons outside of our '\
+        'control. We advise you to retry later."}]}'
+      end
+      allow_any_instance_of(Faraday::Connection).to receive(:get) { response }
+    end
+
+    let(:hunter) { Hunter.new(key) }
+
+    it 'returns delayed status for email_verifier' do
+      expect(hunter.email_verifier('hello@prospect.io').status).to eq('delayed')
+    end
+  end
 end


### PR DESCRIPTION
Closes #3 

The response code indicates trying again later, so handling it the same as delayed makes sense. Currently it fails because of the lack of a data field in the response with a generic ruby error (NoMethodError on nil).